### PR TITLE
Fix non-working hot-reloading in dev environment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,12 +31,14 @@ services:
   frontend:
     image: learningpage-frontend:local-dev
     build: frontend
-    command: nodemon --ext ts,tsx,css --ignore .next --exec "BASE_PATH=/services/learningpage-frontend next dev -H 0.0.0.0"
+    command: npm run dev -- -H 0.0.0.0
     depends_on:
       - backend
     volumes:
       # for local development mount frontend folder
-      - ./frontend/src:/app/src
+      - ./frontend/src:/app/src:cached
+    environment:
+      BASE_PATH: /services/learningpage-frontend
     restart: unless-stopped
   # Jupyterhub to control it all
   jupyterhub:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:13-slim
 
-RUN npm install -g nodemon
-
 WORKDIR /app
 COPY . /app
 RUN npm install


### PR DESCRIPTION
This PR get's rid of nodemon and instead configures the setup properly such that the internal hot-reload mechanism works. In the previous configuration nodemon intercepted too early so that hot-reloading never had a chance to kick-in.